### PR TITLE
修复 无法刷入 Magisk 模块

### DIFF
--- a/magisk/META-INF/com/google/android/update-binary
+++ b/magisk/META-INF/com/google/android/update-binary
@@ -6,151 +6,28 @@
 
 umask 022
 
-# Global vars
-TMPDIR=/dev/tmp
-PERSISTDIR=/sbin/.magisk/mirror/persist
-
-rm -rf $TMPDIR 2>/dev/null
-mkdir -p $TMPDIR
-
 # echo before loading util_functions
 ui_print() { echo "$1"; }
 
 require_new_magisk() {
-  ui_print "May NOT Support Your Magisk."
+  ui_print "*******************************"
+  ui_print " Please install Magisk v20.4+! "
+  ui_print "*******************************"
+  exit 1
 }
 
-is_legacy_script() {
-  unzip -l "$ZIPFILE" install.sh | grep -q install.sh
-  return $?
-}
-
-print_modname() {
-ui_print " Powered by Magisk (@topjohnwu)     "
-}
-
-
-##############
-# Environment
-##############
+#########################
+# Load util_functions.sh
+#########################
 
 OUTFD=$2
 ZIPFILE=$3
 
 mount /data 2>/dev/null
 
-# Load utility functions
 [ -f /data/adb/magisk/util_functions.sh ] || require_new_magisk
 . /data/adb/magisk/util_functions.sh
+[ $MAGISK_VER_CODE -lt 20400 ] && require_new_magisk
 
-
-# Preperation for flashable zips
-setup_flashable
-
-# Mount partitions
-mount_partitions
-
-# Detect version and architecture
-api_level_arch_detect
-
-# Setup busybox and binaries
-$BOOTMODE && boot_actions || recovery_actions
-
-##############
-# Preparation
-##############
-
-# Extract prop file
-unzip -o "$ZIPFILE" module.prop -d $TMPDIR >&2
-[ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
-
-$BOOTMODE && MODDIRNAME=modules_update || MODDIRNAME=modules
-MODULEROOT=$NVBASE/$MODDIRNAME
-MODID=`grep_prop id $TMPDIR/module.prop`
-MODPATH=$MODULEROOT/$MODID
-MODNAME=`grep_prop name $TMPDIR/module.prop`
-MODVER=`grep_prop versionCode $TMPDIR/module.prop`
-
-# Create mod paths
-rm -rf $MODPATH 2>/dev/null
-mkdir -p $MODPATH
-
-##########
-# Install
-##########
-
-if is_legacy_script; then
-  unzip -oj "$ZIPFILE" module.prop install.sh uninstall.sh 'common/*' -d $TMPDIR >&2
-
-  # Load install script
-  . $TMPDIR/install.sh
-
-  # Callbacks
-  print_modname
-  on_install
-  
-  # Custom uninstaller
-  [ -f $TMPDIR/uninstall.sh ] && cp -af $TMPDIR/uninstall.sh $MODPATH/uninstall.sh
-
-  # Skip mount
-  $SKIPMOUNT && touch $MODPATH/skip_mount
-
-  # prop file
-  $PROPFILE && cp -af $TMPDIR/system.prop $MODPATH/system.prop
-
-  # Module info
-  cp -af $TMPDIR/module.prop $MODPATH/module.prop
-
-  # post-fs-data scripts
-  $POSTFSDATA && cp -af $TMPDIR/post-fs-data.sh $MODPATH/post-fs-data.sh
-
-  # service scripts
-  $LATESTARTSERVICE && cp -af $TMPDIR/service.sh $MODPATH/service.sh
-
-  ui_print "- Setting permissions"
-  set_permissions
-else
-  print_modname
- 
-  unzip -o "$ZIPFILE" customize.sh -d $MODPATH >&2
-
-  if ! grep -q '^SKIPUNZIP=1$' $MODPATH/customize.sh 2>/dev/null; then
-    ui_print "- Extracting module files"
-    unzip -o "$ZIPFILE" -x 'META-INF/*' -d $MODPATH >&2
-
-    # Default permissions
-    set_perm_recursive  $MODPATH  0  0  0755  0644
-    
-  fi
-
-  # Load customization script
-  [ -f $MODPATH/customize.sh ] && . $MODPATH/customize.sh
-fi
-
-# Handle replace folders
-for TARGET in $REPLACE; do
-  mktouch $MODPATH$TARGET/.replace
-done
-
-if $BOOTMODE; then
-  # Update info for Magisk Manager
-  mktouch $NVBASE/modules/$MODID/update
-  cp -af $MODPATH/module.prop $NVBASE/modules/$MODID/module.prop
-fi
-
-
-# Remove stuffs that don't belong to modules
-rm -rf \
-$MODPATH/system/placeholder $MODPATH/customize.sh \
-$MODPATH/README.md $MODPATH/.git* 2>/dev/null
-
-##############
-# Finalizing
-##############
-
-cd /
-$BOOTMODE || recovery_cleanup
-rm -rf $TMPDIR
-
-ui_print "- Done"
+install_module
 exit 0


### PR DESCRIPTION
刷入时显示Done，实际根本没有安装。
![Screenshot_20240813-231504_Settings](https://github.com/user-attachments/assets/923d368c-152c-48ab-8dab-1d6d5655fb29)


Magisk 版本: `0495468d (27006)`

~~根据经验~~将 zip 内 `update-binary` 替换为 [update-binary](https://github.com/Zackptg5/MMT-Extended/blob/master/META-INF/com/google/android/update-binary) 后正常工作
![Screenshot_20240813-231528_Settings](https://github.com/user-attachments/assets/15d8efb1-fe54-4264-a2ef-95d66e7ad89b)
