### PR TITLE
Fix GitHub token usage in release workflow

### DIFF
--- a/.github/workflows/Create Release.yml
+++ b/.github/workflows/Create Release.yml
@@ -172,6 +172,8 @@ jobs:
       - name: Create Release
         id: release
         uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.VERSION }}
           name: ${{ env.RELEASE_NAME }}
@@ -182,7 +184,6 @@ jobs:
             ./apk/*.apk
           draft: false
           repository: TimeBreeze/Tritium
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           fail_on_unmatched_files: false
 
       - name: Update Release Info


### PR DESCRIPTION
Updated the Create Release workflow to use a fallback mechanism for the GitHub token by prioritizing `CUSTOM_GITHUB_TOKEN` and defaulting to `GITHUB_TOKEN`. This ensures better flexibility and avoids potential token-related issues.